### PR TITLE
Use JavaScriptInterface for passing converted content.

### DIFF
--- a/PCSHTMLConverter.js
+++ b/PCSHTMLConverter.js
@@ -59,7 +59,13 @@ function convertMobileSectionsJSONToMobileHTML(leadJSON, remainingJSON, domain, 
           description_source: leadJSON.description_source
       }
     }
-    return convertParsoidHTMLToMobileHTML(parsoidHTML, metadata)
+    var html = convertParsoidHTMLToMobileHTML(parsoidHTML, metadata)
+    // If we have a receiver interface for receiving the converted HTML, then pass the content to it.
+    if (conversionClient) {
+        conversionClient.onReceiveHtml(html)
+        return;
+    }
+    return html;
 }
 //  *   {!array} protection
 //  *   {?Object} originalimage


### PR DESCRIPTION
When content from the WebView is passed through a `JavascriptInterface`, it is encoded properly and does not need to be re-decoded on the Java side.  This saves us from performing a very expensive operation when converting.